### PR TITLE
Use LinkedHashSet in LoadingCache.java

### DIFF
--- a/jetcache-core/src/main/java/com/alicp/jetcache/LoadingCache.java
+++ b/jetcache-core/src/main/java/com/alicp/jetcache/LoadingCache.java
@@ -3,7 +3,7 @@ package com.alicp.jetcache;
 import com.alicp.jetcache.event.CacheEvent;
 
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -58,7 +58,7 @@ public class LoadingCache<K, V> extends SimpleProxyCache<K, V> {
             } else {
                 kvMap = new HashMap<>();
             }
-            Set<K> keysNeedLoad = new HashSet<>();
+            Set<K> keysNeedLoad = new LinkedHashSet<>();
             keys.forEach((k) -> {
                 if (!kvMap.containsKey(k)) {
                     keysNeedLoad.add(k);


### PR DESCRIPTION
The test in `com.alicp.jetcache.embedded.CaffeineCacheTest#test` can fail due to a different iteration order of HashSet. The assertion failure is presented as follows.
`org.junit.ComparisonFailure`:
expected:`<LoadingCache_Key2_V1>` 
but was:  `<LoadingCache_Key2_V2>`
at com.alicp.jetcache.embedded.CaffeineCacheTest.test(CaffeineCacheTest.java:22)

The assertion statement causing failure is in `LoadingCacheTest.java:134`:
`Assert.assertEquals("LoadingCache_Key2_V1", map.get("LoadingCache_Key2")); `

The test in `com.alicp.jetcache.embedded.LinkedHashMapCacheTest#test` also suffers from the same issue.

The root cause of these failures lies in LoadingCache.java, where `keysNeedLoad` is implemented as a HashSet. The specification about HashSet says that "it makes no guarantees as to the iteration order of the set; in particular, it does not guarantee that the order will remain constant over time". The documentation is here for your reference: https://docs.oracle.com/javase/8/docs/api/java/util/HashSet.html

The fix is to change HashSet into LinkedHashSet, and the non-deterministic behaviour is eliminated completely, thus making the test more stable.



