### PR TITLE
Remove unused dependencies

### DIFF
--- a/samples/springbootsample/pom.xml
+++ b/samples/springbootsample/pom.xml
@@ -26,6 +26,12 @@
             <groupId>com.alicp.jetcache</groupId>
             <artifactId>jetcache-starter-redis</artifactId>
             <version>2.5.11</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-logging</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
@areyouok Hi, I am a user of project **_com.alicp.jetcache.samples:spring-boot-sample:1.0.0-SNAPSHOT_**. I found that its pom file introduced **_33_** dependencies. However, among them, **_6_** libraries (**_18%_**) have not been used by your project (the redundant dependencies are listed below). This PR helps **_com.alicp.jetcache.samples:spring-boot-sample:1.0.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
org.slf4j:log4j-over-slf4j:jar:1.7.25:compile
org.springframework.boot:spring-boot-starter-logging:jar:1.5.12.RELEASE:compile
ch.qos.logback:logback-core:jar:1.1.11:compile
org.slf4j:jcl-over-slf4j:jar:1.7.25:compile
ch.qos.logback:logback-classic:jar:1.1.11:compile
org.slf4j:jul-to-slf4j:jar:1.7.25:compile
</code></pre>