### PR TITLE
Fix flaky test based on NonDex

### DIFF
--- a/jetcache-test/src/main/java/com/alicp/jetcache/test/AbstractCacheTest.java
+++ b/jetcache-test/src/main/java/com/alicp/jetcache/test/AbstractCacheTest.java
@@ -868,6 +868,12 @@ public abstract class AbstractCacheTest {
             countDownLatch.countDown();
         }).start();
         new Thread(() -> {
+            if (c.get(2003) != 2103) {
+                failMsg[0] = "value error";
+            }
+            countDownLatch.countDown();
+        }).start();
+        new Thread(() -> {
             if (c.computeIfAbsent(2001, loaderFunction) != 2101) {
                 failMsg[0] = "value error";
             }


### PR DESCRIPTION
Hi, I run the test with Nondex(https://github.com/TestingResearchIllinois/NonDex) and it turns out that several tests' behavior will be altered under non-deterministic cases:
-com.alicp.jetcache.LoadingCacheTest.test
-com.alicp.jetcache.RefreshCacheTest.baseTest

I changed normal concurrenthashMap to ConcurrentSkipListMap, as well as test case values to avoid potential non-deterministic behaviors/collisions during the test. Please let me know if you want to discuss more about this fix. Thanks.
