### PR TITLE
fix flaky test based on NonDex report

### DIFF
--- a/jetcache-test/src/main/java/com/alicp/jetcache/test/AbstractCacheTest.java
+++ b/jetcache-test/src/main/java/com/alicp/jetcache/test/AbstractCacheTest.java
@@ -12,7 +12,7 @@ import org.slf4j.LoggerFactory;
 import java.io.Serializable;
 import java.time.Duration;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -826,7 +826,7 @@ public abstract class AbstractCacheTest {
         String failMsg[] = new String[1];
 
         Function<Integer, Integer> loaderFunction = new Function<Integer, Integer>() {
-            ConcurrentHashMap<Integer, Integer> map = new ConcurrentHashMap<>();
+            ConcurrentSkipListMap<Integer, Integer> map = new ConcurrentSkipListMap<>();
             @Override
             public Integer apply(Integer key) {
                 try {
@@ -868,6 +868,12 @@ public abstract class AbstractCacheTest {
             countDownLatch.countDown();
         }).start();
         new Thread(() -> {
+            if (c.get(2003) != 2103) {
+                failMsg[0] = "value error";
+            }
+            countDownLatch.countDown();
+        }).start();
+        new Thread(() -> {
             if (c.computeIfAbsent(2001, loaderFunction) != 2101) {
                 failMsg[0] = "value error";
             }
@@ -875,10 +881,10 @@ public abstract class AbstractCacheTest {
         }).start();
         new Thread(() -> {
             Set<Integer> s = new HashSet<>();
-            s.add(2001);
+            s.add(2003);
             s.add(2002);
             Map<Integer, Integer> values = c.getAll(s);
-            if (values.get(2001) != 2101) {
+            if (values.get(2003) != 2101) {
                 failMsg[0] = "value error";
             }
             if (values.get(2002) != 2102) {

--- a/jetcache-test/src/main/java/com/alicp/jetcache/test/AbstractCacheTest.java
+++ b/jetcache-test/src/main/java/com/alicp/jetcache/test/AbstractCacheTest.java
@@ -884,7 +884,7 @@ public abstract class AbstractCacheTest {
             s.add(2003);
             s.add(2002);
             Map<Integer, Integer> values = c.getAll(s);
-            if (values.get(2003) != 2101) {
+            if (values.get(2003) != 2103) {
                 failMsg[0] = "value error";
             }
             if (values.get(2002) != 2102) {


### PR DESCRIPTION
Hi, I run the test with Nondex(https://github.com/TestingResearchIllinois/NonDex) and it turns out that several tests' behavior will be altered under non-deterministic cases:
-com.alicp.jetcache.LoadingCacheTest.test
-com.alicp.jetcache.RefreshCacheTest.baseTest
I changed normal concurrenthashMap to ConcurrentSkipListMap, as well as test case values to avoid potential non-deterministic behaviors/collisions during the test. Please let me know if you want to discuss more about this fix. Thanks.
