### PR TITLE
Fix GlobalCacheConfig and SpringConfigProvider loop dependencies.

### DIFF
--- a/jetcache-starter/jetcache-autoconfigure/src/main/java/com/alicp/jetcache/autoconfigure/JetCacheAutoConfiguration.java
+++ b/jetcache-starter/jetcache-autoconfigure/src/main/java/com/alicp/jetcache/autoconfigure/JetCacheAutoConfiguration.java
@@ -51,9 +51,7 @@ public class JetCacheAutoConfiguration {
     }
 
     @Bean(name = GLOBAL_CACHE_CONFIG_NAME)
-    public GlobalCacheConfig globalCacheConfig(SpringConfigProvider configProvider,
-                                                            AutoConfigureBeans autoConfigureBeans,
-                                                            JetCacheProperties props) {
+    public GlobalCacheConfig globalCacheConfig(AutoConfigureBeans autoConfigureBeans, JetCacheProperties props) {
         if (_globalCacheConfig != null) {
             return _globalCacheConfig;
         }


### PR DESCRIPTION
修复 GlobalCacheConfig 和 SpringConfigProvider 他们的循环依赖，实际上 SpringConfigProvider configProvider 这个方法参数也没用到去掉之后可以运行。

issues 624 就是这个问题，可以先这样解决一下：https://github.com/alibaba/jetcache/issues/624

GlobalCacheConfig 在方法参数上依赖了 SpringConfigProvider bean，实际上没用到， 

```java
@Bean(name = GLOBAL_CACHE_CONFIG_NAME)
public GlobalCacheConfig globalCacheConfig(SpringConfigProvider configProvider,
                                                        AutoConfigureBeans autoConfigureBeans,
                                                        JetCacheProperties props) {
    if (_globalCacheConfig != null) {
        return _globalCacheConfig;
    }
    _globalCacheConfig = new GlobalCacheConfig();
    _globalCacheConfig.setHiddenPackages(props.getHiddenPackages());
    _globalCacheConfig.setStatIntervalMinutes(props.getStatIntervalMinutes());
    _globalCacheConfig.setAreaInCacheName(props.isAreaInCacheName());
    _globalCacheConfig.setPenetrationProtect(props.isPenetrationProtect());
    _globalCacheConfig.setEnableMethodCache(props.isEnableMethodCache());
    _globalCacheConfig.setLocalCacheBuilders(autoConfigureBeans.getLocalCacheBuilders());
    _globalCacheConfig.setRemoteCacheBuilders(autoConfigureBeans.getRemoteCacheBuilders());
    return _globalCacheConfig;
}
```

SpringConfigProvider 的父类上又 @Resource 依赖了 globalCacheConfig

```java 
public class ConfigProvider extends AbstractLifecycle {

    @Resource
    protected GlobalCacheConfig globalCacheConfig;

```
