### PR TITLE
添加对redisson的支持

### DIFF
--- a/jetcache-starter/jetcache-autoconfigure/src/main/java/com/alicp/jetcache/autoconfigure/JetCacheAutoConfiguration.java
+++ b/jetcache-starter/jetcache-autoconfigure/src/main/java/com/alicp/jetcache/autoconfigure/JetCacheAutoConfiguration.java
@@ -23,7 +23,8 @@ import org.springframework.context.annotation.Import;
         MockRemoteCacheAutoConfiguration.class,
         LinkedHashMapAutoConfiguration.class,
         RedisLettuceAutoConfiguration.class,
-        RedisSpringDataAutoConfiguration.class})
+        RedisSpringDataAutoConfiguration.class,
+        RedissonAutoConfiguration.class})
 public class JetCacheAutoConfiguration {
 
     public static final String GLOBAL_CACHE_CONFIG_NAME = "globalCacheConfig";
@@ -46,7 +47,7 @@ public class JetCacheAutoConfiguration {
     }
 
     @Bean
-    public static BeanDependencyManager beanDependencyManager(){
+    public static BeanDependencyManager beanDependencyManager() {
         return new BeanDependencyManager();
     }
 

--- a/jetcache-starter/jetcache-autoconfigure/src/main/java/com/alicp/jetcache/autoconfigure/RedissonAutoConfiguration.java
+++ b/jetcache-starter/jetcache-autoconfigure/src/main/java/com/alicp/jetcache/autoconfigure/RedissonAutoConfiguration.java
@@ -1,0 +1,55 @@
+package com.alicp.jetcache.autoconfigure;
+
+import com.alicp.jetcache.CacheBuilder;
+import com.alicp.jetcache.external.ExternalCacheBuilder;
+import com.alicp.jetcache.redisson.RedissonCacheBuilder;
+import org.redisson.api.RedissonClient;
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Created on 2022/7/12.
+ *
+ * @author <a href="mailto:jeason1914@qq.com">yangyong</a>
+ */
+@Configuration
+@Conditional(RedissonAutoConfiguration.RedissonCondition.class)
+public class RedissonAutoConfiguration {
+    private static final String CACHE_TYPE = "redisson";
+
+    public static class RedissonCondition extends JetCacheCondition {
+        public RedissonCondition() {
+            super(CACHE_TYPE);
+        }
+    }
+
+    @Bean
+    public RedissonAutoInit redissonAutoInit() {
+        return new RedissonAutoInit();
+    }
+
+    public static class RedissonAutoInit extends ExternalCacheAutoInit implements ApplicationContextAware {
+        private ApplicationContext context;
+
+        public RedissonAutoInit() {
+            super(CACHE_TYPE);
+        }
+
+        @Override
+        protected CacheBuilder initCache(final ConfigTree ct, final String cacheAreaWithPrefix) {
+            final RedissonClient client = this.context.getBean(RedissonClient.class);
+            final ExternalCacheBuilder<?> builder = RedissonCacheBuilder.createBuilder().redissonClient(client);
+            parseGeneralConfig(builder, ct);
+            return builder;
+        }
+
+        @Override
+        public void setApplicationContext(final ApplicationContext context) throws BeansException {
+            this.context = context;
+        }
+    }
+}

--- a/jetcache-starter/jetcache-starter-redisson/pom.xml
+++ b/jetcache-starter/jetcache-starter-redisson/pom.xml
@@ -8,9 +8,14 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>jetcache-autoconfigure</artifactId>
+    <artifactId>jetcache-starter-redisson</artifactId>
 
     <dependencies>
+        <dependency>
+            <groupId>com.alicp.jetcache</groupId>
+            <artifactId>jetcache-autoconfigure</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.alicp.jetcache</groupId>
             <artifactId>jetcache-anno</artifactId>
@@ -18,33 +23,8 @@
         </dependency>
         <dependency>
             <groupId>com.alicp.jetcache</groupId>
-            <artifactId>jetcache-redis</artifactId>
-            <version>${project.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.alicp.jetcache</groupId>
-            <artifactId>jetcache-redis-springdata</artifactId>
-            <version>${project.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.alicp.jetcache</groupId>
-            <artifactId>jetcache-redis-lettuce</artifactId>
-            <version>${project.version}</version>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>com.alicp.jetcache</groupId>
             <artifactId>jetcache-redisson</artifactId>
             <version>${project.version}</version>
-            <optional>true</optional>
         </dependency>
-
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-        </dependency>
-
     </dependencies>
 </project>

--- a/jetcache-starter/jetcache-starter-redisson/pom.xml
+++ b/jetcache-starter/jetcache-starter-redisson/pom.xml
@@ -26,5 +26,11 @@
             <artifactId>jetcache-redisson</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.redisson</groupId>
+            <artifactId>redisson-spring-boot-starter</artifactId>
+            <version>${redisson.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/jetcache-support/jetcache-redisson/pom.xml
+++ b/jetcache-support/jetcache-redisson/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>jetcache-parent</artifactId>
+        <groupId>com.alicp.jetcache</groupId>
+        <version>2.7.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jetcache-redisson</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alicp.jetcache</groupId>
+            <artifactId>jetcache-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.redisson</groupId>
+            <artifactId>redisson-spring-boot-starter</artifactId>
+            <version>${redisson.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/jetcache-support/jetcache-redisson/pom.xml
+++ b/jetcache-support/jetcache-redisson/pom.xml
@@ -19,7 +19,7 @@
 
         <dependency>
             <groupId>org.redisson</groupId>
-            <artifactId>redisson-spring-boot-starter</artifactId>
+            <artifactId>redisson</artifactId>
             <version>${redisson.version}</version>
         </dependency>
     </dependencies>

--- a/jetcache-support/jetcache-redisson/src/main/java/com/alicp/jetcache/redisson/RedissonCache.java
+++ b/jetcache-support/jetcache-redisson/src/main/java/com/alicp/jetcache/redisson/RedissonCache.java
@@ -5,10 +5,6 @@ import com.alicp.jetcache.external.AbstractExternalCache;
 import org.redisson.api.RBatch;
 import org.redisson.api.RBucket;
 import org.redisson.api.RedissonClient;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.data.util.Pair;
-import org.springframework.util.CollectionUtils;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -16,7 +12,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 /**
  * Created on 2022/7/12.
@@ -24,7 +19,6 @@ import java.util.stream.Collectors;
  * @author <a href="mailto:jeason1914@qq.com">yangyong</a>
  */
 public class RedissonCache<K, V> extends AbstractExternalCache<K, V> {
-    private final Logger logger = LoggerFactory.getLogger(RedissonCache.class);
     private final RedissonClient client;
     private final RedissonCacheConfig<K, V> config;
 
@@ -56,14 +50,15 @@ public class RedissonCache<K, V> extends AbstractExternalCache<K, V> {
             final RBucket<CacheValueHolder<V>> rb = this.client.getBucket(getCacheKey(key));
             final CacheValueHolder<V> holder = rb.get();
             if (Objects.nonNull(holder)) {
-                if (System.currentTimeMillis() >= holder.getExpireTime()) {
+                final long now = System.currentTimeMillis(), expire = holder.getExpireTime();
+                if (expire > 0 && now >= expire) {
                     return CacheGetResult.EXPIRED_WITHOUT_MSG;
                 }
                 return new CacheGetResult<>(CacheResultCode.SUCCESS, null, holder);
             }
             return CacheGetResult.NOT_EXISTS_WITHOUT_MSG;
         } catch (Throwable e) {
-            logger.warn("do_GET(key: {})-exp: {}", key, e.getMessage());
+            logError("GET", key, e);
             return new CacheGetResult<>(e);
         }
     }
@@ -72,70 +67,109 @@ public class RedissonCache<K, V> extends AbstractExternalCache<K, V> {
     @SuppressWarnings({"unchecked"})
     protected MultiGetResult<K, V> do_GET_ALL(final Set<? extends K> keys) {
         try {
-            final Map<K, CacheGetResult<V>> retMap = CollectionUtils.isEmpty(keys) ? new HashMap<>(0) :
-                    keys.stream()
-                            .map(key -> {
-                                final RBucket<CacheValueHolder<V>> rb = this.client.getBucket(getCacheKey(key));
-                                final CacheValueHolder<V> holder = rb.get();
-                                if (Objects.nonNull(holder)) {
-                                    if (System.currentTimeMillis() >= holder.getExpireTime()) {
-                                        return Pair.of(key, CacheGetResult.EXPIRED_WITHOUT_MSG);
-                                    }
-                                    return Pair.of(key, new CacheGetResult<>(CacheResultCode.SUCCESS, null, holder));
-                                }
-                                return Pair.of(key, CacheGetResult.NOT_EXISTS_WITHOUT_MSG);
-                            })
-                            .collect(Collectors.toMap(Pair::getFirst, Pair::getSecond, (n, o) -> n));
+            final Map<K, CacheGetResult<V>> retMap = new HashMap<>(1 << 4);
+            if (Objects.nonNull(keys) && !keys.isEmpty()) {
+                final Map<K, String> keyMap = new HashMap<>(keys.size());
+                for (K k : keys) {
+                    if (Objects.nonNull(k)) {
+                        final String key = getCacheKey(k);
+                        if (Objects.nonNull(key) && !key.isEmpty()) {
+                            keyMap.put(k, key);
+                        }
+                    }
+                }
+                if (!keyMap.isEmpty()) {
+                    final Map<String, Object> kvMap = this.client.getBuckets().get(keyMap.values().toArray(new String[0]));
+                    final long now = System.currentTimeMillis();
+                    for (K k : keys) {
+                        final String key = keyMap.get(k);
+                        if (Objects.nonNull(key) && Objects.nonNull(kvMap) && !key.isEmpty()) {
+                            final CacheValueHolder<V> holder = (CacheValueHolder<V>) kvMap.get(key);
+                            if (Objects.nonNull(holder)) {
+                                final long expire = holder.getExpireTime();
+                                final CacheGetResult<V> ret = (expire > 0 && now >= expire) ? CacheGetResult.EXPIRED_WITHOUT_MSG :
+                                        new CacheGetResult<>(CacheResultCode.SUCCESS, null, holder);
+                                retMap.put(k, ret);
+                                continue;
+                            }
+                        }
+                        retMap.put(k, CacheGetResult.NOT_EXISTS_WITHOUT_MSG);
+                    }
+                }
+            }
             return new MultiGetResult<>(CacheResultCode.SUCCESS, null, retMap);
         } catch (Throwable e) {
-            logger.warn("do_GET_ALL(keys: {})-exp: {}", keys, e.getMessage());
+            logError("GET_ALL", "keys(" + (Objects.nonNull(keys) ? keys.size() : 0) + ")", e);
             return new MultiGetResult<>(e);
         }
     }
 
     @Override
     protected CacheResult do_PUT(final K key, final V value, final long expireAfterWrite, final TimeUnit timeUnit) {
-        final RBucket<CacheValueHolder<V>> rb = this.client.getBucket(getCacheKey(key));
-        final CacheValueHolder<V> holder = new CacheValueHolder<>(value, timeUnit.toMillis(expireAfterWrite));
-        rb.set(holder, expireAfterWrite, TimeUnit.MILLISECONDS);
-        return CacheGetResult.SUCCESS_WITHOUT_MSG;
+        try {
+            final CacheValueHolder<V> holder = new CacheValueHolder<>(value, timeUnit.toMillis(expireAfterWrite));
+            this.client.getBucket(getCacheKey(key)).set(holder);
+            return CacheGetResult.SUCCESS_WITHOUT_MSG;
+        } catch (Throwable e) {
+            logError("PUT", key, e);
+            return new CacheResult(e);
+        }
     }
 
     @Override
     protected CacheResult do_PUT_ALL(final Map<? extends K, ? extends V> map, final long expireAfterWrite, final TimeUnit timeUnit) {
-        if (!CollectionUtils.isEmpty(map)) {
-            final RBatch batch = this.client.createBatch();
-            map.forEach((k, v) -> {
-                final CacheValueHolder<V> holder = new CacheValueHolder<>(v, timeUnit.toMillis(expireAfterWrite));
-                batch.getBucket(getCacheKey(k)).setAsync(holder, expireAfterWrite, TimeUnit.MILLISECONDS);
-            });
-            batch.execute();
+        try {
+            if (Objects.nonNull(map) && !map.isEmpty()) {
+                final long expire = timeUnit.toMillis(expireAfterWrite);
+                final RBatch batch = this.client.createBatch();
+                map.forEach((k, v) -> {
+                    final CacheValueHolder<V> holder = new CacheValueHolder<>(v, expire);
+                    batch.getBucket(getCacheKey(k)).setAsync(holder);
+                });
+                batch.execute();
+            }
+            return CacheResult.SUCCESS_WITHOUT_MSG;
+        } catch (Throwable e) {
+            logError("PUT_ALL", "map(" + map.size() + ")", e);
+            return new CacheResult(e);
         }
-        return CacheResult.SUCCESS_WITHOUT_MSG;
     }
 
     @Override
     protected CacheResult do_REMOVE(final K key) {
-        final RBucket<CacheValueHolder<V>> rb = this.client.getBucket(getCacheKey(key));
-        rb.delete();
-        return CacheResult.SUCCESS_WITHOUT_MSG;
+        try {
+            final boolean ret = this.client.getBucket(getCacheKey(key)).delete();
+            return ret ? CacheResult.SUCCESS_WITHOUT_MSG : CacheResult.FAIL_WITHOUT_MSG;
+        } catch (Throwable e) {
+            logError("REMOVE", key, e);
+            return new CacheResult(e);
+        }
     }
 
     @Override
     protected CacheResult do_REMOVE_ALL(final Set<? extends K> keys) {
-        if (!CollectionUtils.isEmpty(keys)) {
-            final RBatch batch = this.client.createBatch();
-            keys.forEach(key -> batch.getBucket(getCacheKey(key)).deleteAsync());
-            batch.execute();
+        try {
+            if (Objects.nonNull(keys) && !keys.isEmpty()) {
+                final RBatch batch = this.client.createBatch();
+                keys.forEach(key -> batch.getBucket(getCacheKey(key)).deleteAsync());
+                batch.execute();
+            }
+            return CacheResult.SUCCESS_WITHOUT_MSG;
+        } catch (Throwable e) {
+            logError("REMOVE_ALL", "keys(" + keys.size() + ")", e);
+            return new CacheResult(e);
         }
-        return CacheResult.SUCCESS_WITHOUT_MSG;
     }
 
     @Override
     protected CacheResult do_PUT_IF_ABSENT(final K key, final V value, final long expireAfterWrite, final TimeUnit timeUnit) {
-        final CacheValueHolder<V> holder = new CacheValueHolder<>(value, timeUnit.toMillis(expireAfterWrite));
-        final RBucket<CacheValueHolder<V>> rb = this.client.getBucket(getCacheKey(key));
-        final boolean success = rb.trySet(holder, expireAfterWrite, TimeUnit.MILLISECONDS);
-        return success ? CacheResult.SUCCESS_WITHOUT_MSG : CacheResult.EXISTS_WITHOUT_MSG;
+        try {
+            final CacheValueHolder<V> holder = new CacheValueHolder<>(value, timeUnit.toMillis(expireAfterWrite));
+            final boolean success = this.client.getBucket(getCacheKey(key)).trySet(holder, expireAfterWrite, timeUnit);
+            return success ? CacheResult.SUCCESS_WITHOUT_MSG : CacheResult.EXISTS_WITHOUT_MSG;
+        } catch (Throwable e) {
+            logError("PUT_IF_ABSENT", key, e);
+            return new CacheResult(e);
+        }
     }
 }

--- a/jetcache-support/jetcache-redisson/src/main/java/com/alicp/jetcache/redisson/RedissonCache.java
+++ b/jetcache-support/jetcache-redisson/src/main/java/com/alicp/jetcache/redisson/RedissonCache.java
@@ -1,0 +1,141 @@
+package com.alicp.jetcache.redisson;
+
+import com.alicp.jetcache.*;
+import com.alicp.jetcache.external.AbstractExternalCache;
+import org.redisson.api.RBatch;
+import org.redisson.api.RBucket;
+import org.redisson.api.RedissonClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.util.Pair;
+import org.springframework.util.CollectionUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+/**
+ * Created on 2022/7/12.
+ *
+ * @author <a href="mailto:jeason1914@qq.com">yangyong</a>
+ */
+public class RedissonCache<K, V> extends AbstractExternalCache<K, V> {
+    private final Logger logger = LoggerFactory.getLogger(RedissonCache.class);
+    private final RedissonClient client;
+    private final RedissonCacheConfig<K, V> config;
+
+    public RedissonCache(final RedissonCacheConfig<K, V> config) {
+        super(config);
+        this.config = config;
+        this.client = config.getRedissonClient();
+    }
+
+    protected String getCacheKey(final K key) {
+        final byte[] newKey = buildKey(key);
+        return new String(newKey, StandardCharsets.UTF_8);
+    }
+
+    @Override
+    public CacheConfig<K, V> config() {
+        return this.config;
+    }
+
+    @Override
+    public <T> T unwrap(final Class<T> clazz) {
+        throw new UnsupportedOperationException("RedissonCache does not support unwrap");
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked"})
+    protected CacheGetResult<V> do_GET(final K key) {
+        try {
+            final RBucket<CacheValueHolder<V>> rb = this.client.getBucket(getCacheKey(key));
+            final CacheValueHolder<V> holder = rb.get();
+            if (Objects.nonNull(holder)) {
+                if (System.currentTimeMillis() >= holder.getExpireTime()) {
+                    return CacheGetResult.EXPIRED_WITHOUT_MSG;
+                }
+                return new CacheGetResult<>(CacheResultCode.SUCCESS, null, holder);
+            }
+            return CacheGetResult.NOT_EXISTS_WITHOUT_MSG;
+        } catch (Throwable e) {
+            logger.warn("do_GET(key: {})-exp: {}", key, e.getMessage());
+            return new CacheGetResult<>(e);
+        }
+    }
+
+    @Override
+    @SuppressWarnings({"unchecked"})
+    protected MultiGetResult<K, V> do_GET_ALL(final Set<? extends K> keys) {
+        try {
+            final Map<K, CacheGetResult<V>> retMap = CollectionUtils.isEmpty(keys) ? new HashMap<>(0) :
+                    keys.stream()
+                            .map(key -> {
+                                final RBucket<CacheValueHolder<V>> rb = this.client.getBucket(getCacheKey(key));
+                                final CacheValueHolder<V> holder = rb.get();
+                                if (Objects.nonNull(holder)) {
+                                    if (System.currentTimeMillis() >= holder.getExpireTime()) {
+                                        return Pair.of(key, CacheGetResult.EXPIRED_WITHOUT_MSG);
+                                    }
+                                    return Pair.of(key, new CacheGetResult<>(CacheResultCode.SUCCESS, null, holder));
+                                }
+                                return Pair.of(key, CacheGetResult.NOT_EXISTS_WITHOUT_MSG);
+                            })
+                            .collect(Collectors.toMap(Pair::getFirst, Pair::getSecond, (n, o) -> n));
+            return new MultiGetResult<>(CacheResultCode.SUCCESS, null, retMap);
+        } catch (Throwable e) {
+            logger.warn("do_GET_ALL(keys: {})-exp: {}", keys, e.getMessage());
+            return new MultiGetResult<>(e);
+        }
+    }
+
+    @Override
+    protected CacheResult do_PUT(final K key, final V value, final long expireAfterWrite, final TimeUnit timeUnit) {
+        final RBucket<CacheValueHolder<V>> rb = this.client.getBucket(getCacheKey(key));
+        final CacheValueHolder<V> holder = new CacheValueHolder<>(value, timeUnit.toMillis(expireAfterWrite));
+        rb.set(holder, expireAfterWrite, TimeUnit.MILLISECONDS);
+        return CacheGetResult.SUCCESS_WITHOUT_MSG;
+    }
+
+    @Override
+    protected CacheResult do_PUT_ALL(final Map<? extends K, ? extends V> map, final long expireAfterWrite, final TimeUnit timeUnit) {
+        if (!CollectionUtils.isEmpty(map)) {
+            final RBatch batch = this.client.createBatch();
+            map.forEach((k, v) -> {
+                final CacheValueHolder<V> holder = new CacheValueHolder<>(v, timeUnit.toMillis(expireAfterWrite));
+                batch.getBucket(getCacheKey(k)).setAsync(holder, expireAfterWrite, TimeUnit.MILLISECONDS);
+            });
+            batch.execute();
+        }
+        return CacheResult.SUCCESS_WITHOUT_MSG;
+    }
+
+    @Override
+    protected CacheResult do_REMOVE(final K key) {
+        final RBucket<CacheValueHolder<V>> rb = this.client.getBucket(getCacheKey(key));
+        rb.delete();
+        return CacheResult.SUCCESS_WITHOUT_MSG;
+    }
+
+    @Override
+    protected CacheResult do_REMOVE_ALL(final Set<? extends K> keys) {
+        if (!CollectionUtils.isEmpty(keys)) {
+            final RBatch batch = this.client.createBatch();
+            keys.forEach(key -> batch.getBucket(getCacheKey(key)).deleteAsync());
+            batch.execute();
+        }
+        return CacheResult.SUCCESS_WITHOUT_MSG;
+    }
+
+    @Override
+    protected CacheResult do_PUT_IF_ABSENT(final K key, final V value, final long expireAfterWrite, final TimeUnit timeUnit) {
+        final CacheValueHolder<V> holder = new CacheValueHolder<>(value, timeUnit.toMillis(expireAfterWrite));
+        final RBucket<CacheValueHolder<V>> rb = this.client.getBucket(getCacheKey(key));
+        final boolean success = rb.trySet(holder, expireAfterWrite, TimeUnit.MILLISECONDS);
+        return success ? CacheResult.SUCCESS_WITHOUT_MSG : CacheResult.EXISTS_WITHOUT_MSG;
+    }
+}

--- a/jetcache-support/jetcache-redisson/src/main/java/com/alicp/jetcache/redisson/RedissonCacheBuilder.java
+++ b/jetcache-support/jetcache-redisson/src/main/java/com/alicp/jetcache/redisson/RedissonCacheBuilder.java
@@ -1,0 +1,39 @@
+package com.alicp.jetcache.redisson;
+
+import com.alicp.jetcache.external.ExternalCacheBuilder;
+import org.redisson.api.RedissonClient;
+
+/**
+ * Created on 2022/7/12.
+ *
+ * @author <a href="mailto:jeason1914@qq.com">yangyong</a>
+ */
+public class RedissonCacheBuilder<T extends ExternalCacheBuilder<T>> extends ExternalCacheBuilder<T> {
+
+    public static class RedissonDataCacheBuilderImpl extends RedissonCacheBuilder<RedissonDataCacheBuilderImpl> {
+
+    }
+
+    public static RedissonDataCacheBuilderImpl createBuilder() {
+        return new RedissonDataCacheBuilderImpl();
+    }
+
+    @SuppressWarnings({"all"})
+    protected RedissonCacheBuilder() {
+        buildFunc(config -> new RedissonCache((RedissonCacheConfig) config));
+    }
+
+    @Override
+    @SuppressWarnings({"all"})
+    public RedissonCacheConfig getConfig() {
+        if (this.config == null) {
+            this.config = new RedissonCacheConfig();
+        }
+        return (RedissonCacheConfig) this.config;
+    }
+
+    public T redissonClient(final RedissonClient client) {
+        this.getConfig().setRedissonClient(client);
+        return self();
+    }
+}

--- a/jetcache-support/jetcache-redisson/src/main/java/com/alicp/jetcache/redisson/RedissonCacheConfig.java
+++ b/jetcache-support/jetcache-redisson/src/main/java/com/alicp/jetcache/redisson/RedissonCacheConfig.java
@@ -1,0 +1,21 @@
+package com.alicp.jetcache.redisson;
+
+import com.alicp.jetcache.external.ExternalCacheConfig;
+import org.redisson.api.RedissonClient;
+
+/**
+ * Created on 2022/7/12.
+ *
+ * @author <a href="mailto:jeason1914@qq.com">yangyong</a>
+ */
+public class RedissonCacheConfig<K, V> extends ExternalCacheConfig<K, V> {
+    private RedissonClient redissonClient;
+
+    public RedissonClient getRedissonClient() {
+        return redissonClient;
+    }
+
+    public void setRedissonClient(final RedissonClient redissonClient) {
+        this.redissonClient = redissonClient;
+    }
+}

--- a/jetcache-test/pom.xml
+++ b/jetcache-test/pom.xml
@@ -60,6 +60,11 @@
         </dependency>
         <dependency>
             <groupId>com.alicp.jetcache</groupId>
+            <artifactId>jetcache-starter-redisson</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.alicp.jetcache</groupId>
             <artifactId>jetcache-autoconfigure</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/jetcache-test/src/test/java/com/alicp/jetcache/autoconfigure/RedissonStarterTest.java
+++ b/jetcache-test/src/test/java/com/alicp/jetcache/autoconfigure/RedissonStarterTest.java
@@ -1,0 +1,56 @@
+package com.alicp.jetcache.autoconfigure;
+
+import com.alicp.jetcache.Cache;
+import com.alicp.jetcache.anno.CreateCache;
+import com.alicp.jetcache.anno.config.EnableCreateCacheAnnotation;
+import com.alicp.jetcache.anno.config.EnableMethodCache;
+import com.alicp.jetcache.test.beans.MyFactoryBean;
+import com.alicp.jetcache.test.spring.SpringTest;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+/**
+ * Created on 2022/7/13.
+ *
+ * @author <a href="mailto:jeason1914@qq.com">yangyong</a>
+ */
+@Configuration
+@EnableAutoConfiguration
+@ComponentScan(basePackages = {"com.alicp.jetcache.test.beans", "com.alicp.jetcache.anno.inittestbeans"})
+@EnableMethodCache(basePackages = {"com.alicp.jetcache.test.beans", "com.alicp.jetcache.anno.inittestbeans"})
+@EnableCreateCacheAnnotation
+@Ignore
+public class RedissonStarterTest extends SpringTest {
+
+    @Test
+    public void tests() throws Exception {
+        System.setProperty("spring.profiles.active", "redisson");
+        context = SpringApplication.run(RedissonStarterTest.class);
+        doTest();
+    }
+
+    @Component
+    public static class A {
+        @CreateCache
+        private Cache cache;
+
+        @PostConstruct
+        public void test() {
+            Assert.assertTrue(cache.PUT("K", "V").isSuccess());
+        }
+    }
+
+    @Bean(name = "factoryBeanTarget")
+    public MyFactoryBean factoryBean() {
+        return new MyFactoryBean();
+    }
+}

--- a/jetcache-test/src/test/java/com/alicp/jetcache/redisson/RedissonCacheTest.java
+++ b/jetcache-test/src/test/java/com/alicp/jetcache/redisson/RedissonCacheTest.java
@@ -1,0 +1,79 @@
+package com.alicp.jetcache.redisson;
+
+import com.alicp.jetcache.LoadingCacheTest;
+import com.alicp.jetcache.RefreshCacheTest;
+import com.alicp.jetcache.support.*;
+import com.alicp.jetcache.test.external.AbstractExternalCacheTest;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created on 2022/7/13.
+ *
+ * @author <a href="mailto:jeason1914@qq.com">yangyong</a>
+ */
+@Ignore
+public class RedissonCacheTest extends AbstractExternalCacheTest {
+
+    @Test
+    public void redissonTest() throws Exception {
+        final Config config = new Config();
+        config.useSingleServer().setAddress("redis://127.0.0.1:6379").setDatabase(0);
+        doTest(Redisson.create(config));
+    }
+
+    private void doTest(final RedissonClient redissonClient) throws Exception {
+        cache = RedissonCacheBuilder.createBuilder()
+                .keyConvertor(FastjsonKeyConvertor.INSTANCE)
+                .valueEncoder(JavaValueEncoder.INSTANCE)
+                .valueDecoder(JavaValueDecoder.INSTANCE)
+                .redissonClient(redissonClient)
+                .keyPrefix(new Random().nextInt() + "")
+                .expireAfterWrite(500, TimeUnit.MILLISECONDS)
+                .buildCache();
+
+        baseTest();
+        fastjsonKeyCoverterTest();
+        expireAfterWriteTest(cache.config().getExpireAfterWriteInMillis());
+
+        LoadingCacheTest.loadingCacheTest(RedissonCacheBuilder.createBuilder()
+                .keyConvertor(FastjsonKeyConvertor.INSTANCE)
+                .valueEncoder(JavaValueEncoder.INSTANCE)
+                .valueDecoder(JavaValueDecoder.INSTANCE)
+                .redissonClient(redissonClient)
+                .keyPrefix(new Random().nextInt() + ""), 0);
+        RefreshCacheTest.refreshCacheTest(RedissonCacheBuilder.createBuilder()
+                .keyConvertor(FastjsonKeyConvertor.INSTANCE)
+                .valueEncoder(JavaValueEncoder.INSTANCE)
+                .valueDecoder(JavaValueDecoder.INSTANCE)
+                .redissonClient(redissonClient)
+                .keyPrefix(new Random().nextInt() + ""), 200, 100);
+
+
+        cache = RedissonCacheBuilder.createBuilder()
+                .keyConvertor(null)
+                .valueEncoder(KryoValueEncoder.INSTANCE)
+                .valueDecoder(KryoValueDecoder.INSTANCE)
+                .redissonClient(redissonClient)
+                .keyPrefix(new Random().nextInt() + "")
+                .buildCache();
+        nullKeyConvertorTest();
+
+        int thread = 10;
+        int time = 3000;
+        cache = RedissonCacheBuilder.createBuilder()
+                .keyConvertor(FastjsonKeyConvertor.INSTANCE)
+                .valueEncoder(KryoValueEncoder.INSTANCE)
+                .valueDecoder(KryoValueDecoder.INSTANCE)
+                .redissonClient(redissonClient)
+                .keyPrefix(new Random().nextInt() + "")
+                .buildCache();
+        concurrentTest(thread, 500, time);
+    }
+}

--- a/jetcache-test/src/test/resources/config/application-redisson.yml
+++ b/jetcache-test/src/test/resources/config/application-redisson.yml
@@ -1,0 +1,37 @@
+jetcache:
+  statIntervalMinutes: 15
+  areaInCacheName: false
+  penetrationProtect: false
+
+  local:
+    default:
+      type: caffeine
+      keyConvertor: fastjson
+      limit: 200
+      defaultExpireInMillis: 10000
+    A1:
+      type: linkedhashmap
+      keyConvertor: fastjson
+      limit: 100
+      expireAfterAccess: true
+      defaultExpireInMillis: 10000
+  remote:
+    default:
+      type: redisson
+      keyConvertor: fastjson
+      defaultExpireInMillis: 10000
+      keyPrefix: spring-data-redis
+    A1:
+      type: redisson
+      keyConvertor: fastjson
+      defaultExpireInMillis: 10000
+      keyPrefix: spring-data-redis-A1
+
+spring:
+  redis:
+    host: 127.0.0.1
+    port: 6379
+    timeout: 1000
+
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -187,11 +187,13 @@
         <module>jetcache-support/jetcache-redis</module>
         <module>jetcache-support/jetcache-redis-lettuce</module>
         <module>jetcache-support/jetcache-redis-springdata</module>
+        <module>jetcache-support/jetcache-redisson</module>
 
         <module>jetcache-starter/jetcache-autoconfigure</module>
         <module>jetcache-starter/jetcache-starter-redis</module>
         <module>jetcache-starter/jetcache-starter-redis-lettuce</module>
         <module>jetcache-starter/jetcache-starter-redis-springdata</module>
+        <module>jetcache-starter/jetcache-starter-redisson</module>
     </modules>
 
     <properties>
@@ -203,6 +205,7 @@
         <spring.boot.version>2.7.0</spring.boot.version>
         <lettuce.version>6.1.8.RELEASE</lettuce.version>
         <jedis.version>4.2.3</jedis.version>
+        <redisson.version>3.17.3</redisson.version>
 
         <!-- 2.6.2
         <spring.framework.version>5.2.4.RELEASE</spring.framework.version>


### PR DESCRIPTION
在项目中针对有多个Redis连接器的访问会合并到同一套Redis连接器，以降低对Redis连接数，更好的提高性能，相比于jedis和lettuce，redisson有更高层次的抽象，在项目中业务中用到redisson的时候比较多，在和jetcache集成时每次都需要自己写代码，在研究了jetcache之后发现，jetcache有较好的兼容性实现方式，所以将代码整合后提交，希望jetcache能增加对redisson的支持