### PR TITLE
fix pom to fit non-spring boot application and remove spring-boot-starter dependency

### DIFF
--- a/jetcache-support/jetcache-redis-springdata/pom.xml
+++ b/jetcache-support/jetcache-redis-springdata/pom.xml
@@ -17,9 +17,14 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-redis</artifactId>
+            <groupId>org.springframework.data</groupId>
+            <artifactId>spring-data-redis</artifactId>
             <version>${spring.boot.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.lettuce</groupId>
+            <artifactId>lettuce-core</artifactId>
+            <version>${lettuce.version}</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
spring boot应用应该依赖jetcache-starter-redis-springdata这个jar包