### PR TITLE
for springboot3 remove javax

### DIFF
--- a/jetcache-anno/src/main/java/com/alicp/jetcache/anno/support/ConfigProvider.java
+++ b/jetcache-anno/src/main/java/com/alicp/jetcache/anno/support/ConfigProvider.java
@@ -14,7 +14,6 @@ import com.alicp.jetcache.template.NotifyMonitorInstaller;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Resource;
 import java.time.Duration;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -28,7 +27,6 @@ public class ConfigProvider extends AbstractLifecycle {
 
     private static final Logger logger = LoggerFactory.getLogger(ConfigProvider.class);
 
-    @Resource
     protected GlobalCacheConfig globalCacheConfig;
 
     protected EncoderParser encoderParser;

--- a/jetcache-anno/src/main/java/com/alicp/jetcache/anno/support/JetCacheBaseBeans.java
+++ b/jetcache-anno/src/main/java/com/alicp/jetcache/anno/support/JetCacheBaseBeans.java
@@ -22,7 +22,7 @@ public class JetCacheBaseBeans {
         return new SpringConfigProvider();
     }
 
-    @Bean
+    @Bean(destroyMethod = "shutdown")
     public SpringConfigProvider springConfigProvider(
             @Autowired ApplicationContext applicationContext,
             @Autowired GlobalCacheConfig globalCacheConfig,

--- a/jetcache-anno/src/main/java/com/alicp/jetcache/anno/support/JetCacheBaseBeans.java
+++ b/jetcache-anno/src/main/java/com/alicp/jetcache/anno/support/JetCacheBaseBeans.java
@@ -48,7 +48,7 @@ public class JetCacheBaseBeans {
         return cp;
     }
 
-    @Bean(name = "jcCacheManager")
+    @Bean(name = "jcCacheManager",destroyMethod = "close")
     public SimpleCacheManager cacheManager(@Autowired ConfigProvider configProvider) {
         SimpleCacheManager cacheManager = new SimpleCacheManager();
         cacheManager.setCacheBuilderTemplate(configProvider.getCacheBuilderTemplate());

--- a/jetcache-core/src/main/java/com/alicp/jetcache/SimpleCacheManager.java
+++ b/jetcache-core/src/main/java/com/alicp/jetcache/SimpleCacheManager.java
@@ -13,7 +13,6 @@ import com.alicp.jetcache.template.QuickConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.PreDestroy;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -38,7 +37,6 @@ public class SimpleCacheManager implements CacheManager, AutoCloseable {
     public SimpleCacheManager() {
     }
 
-    @PreDestroy
     @Override
     public void close() {
         broadcastManagers.forEach((area, bm) -> {

--- a/jetcache-core/src/main/java/com/alicp/jetcache/support/AbstractLifecycle.java
+++ b/jetcache-core/src/main/java/com/alicp/jetcache/support/AbstractLifecycle.java
@@ -3,8 +3,8 @@
  */
 package com.alicp.jetcache.support;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
+
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * @author <a href="mailto:areyouok@gmail.com">huangli</a>
@@ -13,23 +13,33 @@ public class AbstractLifecycle {
     private boolean init;
     private boolean shutdown;
 
-    @PostConstruct
-    public final synchronized void init() {
-        if (!init) {
-            doInit();
-            init = true;
+    final ReentrantLock reentrantLock = new ReentrantLock();
+
+    public final void init() {
+        reentrantLock.lock();
+        try {
+            if (!init) {
+                doInit();
+                init = true;
+            }
+        }finally {
+            reentrantLock.unlock();
         }
     }
 
     protected void doInit() {
     }
 
-    @PreDestroy
-    public final synchronized void shutdown() {
-        if (init && !shutdown) {
-            doShutdown();
-            init = false;
-            shutdown = true;
+    public final void shutdown() {
+        reentrantLock.lock();
+        try {
+            if (init && !shutdown) {
+                doShutdown();
+                init = false;
+                shutdown = true;
+            }
+        }finally {
+            reentrantLock.unlock();
         }
     }
 

--- a/jetcache-core/src/main/java/com/alicp/jetcache/support/DefaultMetricsManager.java
+++ b/jetcache-core/src/main/java/com/alicp/jetcache/support/DefaultMetricsManager.java
@@ -3,8 +3,6 @@ package com.alicp.jetcache.support;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.Arrays;
@@ -12,6 +10,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -30,6 +29,7 @@ public class DefaultMetricsManager {
     private final int resetTime;
     private final TimeUnit resetTimeUnit;
     private final Consumer<StatInfo> metricsCallback;
+    private final ReentrantLock reentrantLock = new ReentrantLock();
 
     public DefaultMetricsManager(int resetTime, TimeUnit resetTimeUnit, Consumer<StatInfo> metricsCallback) {
         this.resetTime = resetTime;
@@ -73,22 +73,31 @@ public class DefaultMetricsManager {
         }
     };
 
-    @PostConstruct
-    public synchronized void start() {
-        if (future != null) {
-            return;
+
+    public void start() {
+        reentrantLock.lock();
+        try {
+            if (future != null) {
+                return;
+            }
+            long delay = firstDelay(resetTime, resetTimeUnit);
+            future = JetCacheExecutor.defaultExecutor().scheduleAtFixedRate(
+                    cmd, delay, resetTimeUnit.toMillis(resetTime), TimeUnit.MILLISECONDS);
+            logger.info("cache stat period at " + resetTime + " " + resetTimeUnit);
+        }finally {
+            reentrantLock.unlock();
         }
-        long delay = firstDelay(resetTime, resetTimeUnit);
-        future = JetCacheExecutor.defaultExecutor().scheduleAtFixedRate(
-                cmd, delay, resetTimeUnit.toMillis(resetTime), TimeUnit.MILLISECONDS);
-        logger.info("cache stat period at " + resetTime + " " + resetTimeUnit);
     }
 
-    @PreDestroy
-    public synchronized void stop() {
-        future.cancel(false);
-        logger.info("cache stat canceled");
-        future = null;
+    public void stop() {
+        reentrantLock.lock();
+        try {
+            future.cancel(false);
+            logger.info("cache stat canceled");
+            future = null;
+        }finally {
+            reentrantLock.unlock();
+        }
     }
 
     public void add(DefaultCacheMonitor... monitors) {

--- a/jetcache-starter/jetcache-autoconfigure/src/main/java/com/alicp/jetcache/autoconfigure/JetCacheAutoConfiguration.java
+++ b/jetcache-starter/jetcache-autoconfigure/src/main/java/com/alicp/jetcache/autoconfigure/JetCacheAutoConfiguration.java
@@ -51,9 +51,9 @@ public class JetCacheAutoConfiguration {
                 encoderParser, keyConvertorParser, metricsCallback);
     }
 
-    @Bean(name = "jcCacheManager")
+    @Bean(name = "jcCacheManager",destroyMethod = "close")
     @ConditionalOnMissingBean
-    public CacheManager cacheManager(@Autowired SpringConfigProvider springConfigProvider) {
+    public SimpleCacheManager cacheManager(@Autowired SpringConfigProvider springConfigProvider) {
         SimpleCacheManager cacheManager = new SimpleCacheManager();
         cacheManager.setCacheBuilderTemplate(springConfigProvider.getCacheBuilderTemplate());
         return cacheManager;

--- a/jetcache-starter/jetcache-autoconfigure/src/main/java/com/alicp/jetcache/autoconfigure/JetCacheAutoConfiguration.java
+++ b/jetcache-starter/jetcache-autoconfigure/src/main/java/com/alicp/jetcache/autoconfigure/JetCacheAutoConfiguration.java
@@ -39,7 +39,7 @@ public class JetCacheAutoConfiguration {
 
     public static final String GLOBAL_CACHE_CONFIG_NAME = "globalCacheConfig";
 
-    @Bean
+    @Bean(destroyMethod = "shutdown")
     @ConditionalOnMissingBean
     public SpringConfigProvider springConfigProvider(
             @Autowired ApplicationContext applicationContext,


### PR DESCRIPTION
问题 #812 


1. Springboot3 的javax迁移问题,删除目前javax,在bean上追加调用(暂时先采用简单的方式,去除)

2. 少量修改synchronized到lock 为后续jdk21 (synchronized涉及比较多,不影响的先改一下,后续的找个时间,我在改一下)