### PR TITLE
fix flaky penetrationProtectTestWithComputeIfAbsent

### DIFF
--- a/jetcache-test/src/main/java/com/alicp/jetcache/test/AbstractCacheTest.java
+++ b/jetcache-test/src/main/java/com/alicp/jetcache/test/AbstractCacheTest.java
@@ -848,7 +848,7 @@ public abstract class AbstractCacheTest {
 
         Assert.assertTrue(cache.remove(keyPrefix + "0"));
         Assert.assertTrue(cache.remove(keyPrefix + "1"));
-        Assert.assertTrue(cache.remove(keyPrefix + "3"));
+        Assert.assertTrue(cache.remove(keyPrefix + "2"));
 
         cache.config().setCachePenetrationProtect(oldPenetrationProtect);
         cache.config().setPenetrationProtectTimeout(oldTime);

--- a/jetcache-test/src/main/java/com/alicp/jetcache/test/AbstractCacheTest.java
+++ b/jetcache-test/src/main/java/com/alicp/jetcache/test/AbstractCacheTest.java
@@ -791,6 +791,11 @@ public abstract class AbstractCacheTest {
 
             @Override
             public Object apply(Object k) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
                 if ((keyPrefix + "1").equals(k)) {
                     // fail 2 times
                     if (count1.getAndIncrement() <= 1) {

--- a/jetcache-test/src/main/java/com/alicp/jetcache/test/AbstractCacheTest.java
+++ b/jetcache-test/src/main/java/com/alicp/jetcache/test/AbstractCacheTest.java
@@ -790,11 +790,8 @@ public abstract class AbstractCacheTest {
 
             @Override
             public Object apply(Object k) {
-                try {
-                    Thread.sleep(100);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
+                // There are a total of 7 threads that can enter, prefix_0 can enter 3 times, prefix_1 can enter 4 times,
+                // and the rest of them will be return cached value.
                 if ((keyPrefix + "0").equals(k)) {
                     // fail 2 times
                     if (count1.getAndIncrement() <= 1) {


### PR DESCRIPTION
Resolve #870

Some of the threads will request a key with `keyPrefix_0`, but it won't cover it on the loader, so it may increase the counter unexpectedly(by race).