### PR TITLE
fix: expiration time did not respect environment variable #915

### DIFF
--- a/jetcache-core/src/main/java/com/alicp/jetcache/MultiLevelCache.java
+++ b/jetcache-core/src/main/java/com/alicp/jetcache/MultiLevelCache.java
@@ -172,8 +172,8 @@ public class MultiLevelCache<K, V> extends AbstractCache<K, V> {
             if (timeUnit == null) {
                 r = cache.PUT(key, value);
             } else {
-                // 只有 isForce = 用户强制 && expire <= 本地缓存时间 才会使用参数的 expire
-                if (isForce && expire <= cache.config().getExpireAfterWriteInMillis()) {
+                // 只有 isForce = 用户强制 或者 expire <= 本地缓存时间 才会使用参数的 expire
+                if (isForce || expire <= cache.config().getExpireAfterWriteInMillis()) {
                     r = cache.PUT(key, value, expire, timeUnit);
                 } else {
                     r = cache.PUT(key, value);

--- a/jetcache-core/src/main/java/com/alicp/jetcache/MultiLevelCache.java
+++ b/jetcache-core/src/main/java/com/alicp/jetcache/MultiLevelCache.java
@@ -61,12 +61,12 @@ public class MultiLevelCache<K, V> extends AbstractCache<K, V> {
 
     @Override
     public CacheResult PUT(K key, V value) {
-        return PUT(key, value, config().getExpireAfterWriteInMillis(), TimeUnit.MILLISECONDS);
+        return PUT(key, value, 0, null);
     }
 
     @Override
     public CacheResult PUT_ALL(Map<? extends K, ? extends V> map) {
-        return PUT_ALL(map, config().getExpireAfterWriteInMillis(), TimeUnit.MILLISECONDS);
+        return PUT_ALL(map, 0, null);
     }
 
     @Override
@@ -101,16 +101,9 @@ public class MultiLevelCache<K, V> extends AbstractCache<K, V> {
         long currentExpire = h.getExpireTime();
         long now = System.currentTimeMillis();
         if (now <= currentExpire) {
-            /*
-            There are two situations here from the legacy version:
-              - if isUseExpireOfSubCache, let subordinate cache choose the expiration time by itself
-              - if not, choose the remaining time of the current cache as the expiration time
-            In the current version, the remaining time of the current cache is always chosen as the expiration time,
-            but a parameter isForce is added to control that it cannot exceed the expiration time that subordinate cache configured
-             */
             long restTtl = currentExpire - now;
             if (restTtl > 0) {
-                PUT_caches(i, key, h.getValue(), restTtl, TimeUnit.MILLISECONDS);
+                PUT_caches(i, key, h.getValue(), restTtl, TimeUnit.MILLISECONDS, true);
             }
         }
     }
@@ -146,38 +139,51 @@ public class MultiLevelCache<K, V> extends AbstractCache<K, V> {
 
     @Override
     protected CacheResult do_PUT(K key, V value, long expireAfterWrite, TimeUnit timeUnit) {
-        return PUT_caches(caches.length, key, value, expireAfterWrite, timeUnit);
+        return PUT_caches(caches.length, key, value, expireAfterWrite, timeUnit, false);
     }
 
     @Override
     protected CacheResult do_PUT_ALL(Map<? extends K, ? extends V> map, long expireAfterWrite, TimeUnit timeUnit) {
+        return PUT_ALL_caches(map, expireAfterWrite, timeUnit, false);
+    }
+
+    private CacheResult PUT_ALL_caches(Map<? extends K, ? extends V> map, long expire,
+                                       TimeUnit timeUnit, boolean limitExpireByCacheConfig) {
         CompletableFuture<ResultData> future = CompletableFuture.completedFuture(null);
         for (Cache c : caches) {
             CacheResult r;
-            if(timeUnit == null) {
+            if (timeUnit == null) {
                 r = c.PUT_ALL(map);
+            } else if (limitExpireByCacheConfig) {
+                r = c.PUT_ALL(map, limitedExpireInMillis(expire, timeUnit, c), TimeUnit.MILLISECONDS);
             } else {
-                r = c.PUT_ALL(map, expireAfterWrite, timeUnit);
+                r = c.PUT_ALL(map, expire, timeUnit);
             }
             future = combine(future, r);
         }
         return new CacheResult(future);
     }
 
-    private CacheResult PUT_caches(int lastIndex, K key, V value, long expire, TimeUnit timeUnit) {
+    private CacheResult PUT_caches(int lastIndex, K key, V value, long expire,
+                                   TimeUnit timeUnit, boolean limitExpireByCacheConfig) {
         CompletableFuture<ResultData> future = CompletableFuture.completedFuture(null);
         for (int i = 0; i < lastIndex; i++) {
             Cache cache = caches[i];
             CacheResult r;
             if (timeUnit == null) {
                 r = cache.PUT(key, value);
+            } else if (limitExpireByCacheConfig) {
+                r = cache.PUT(key, value, limitedExpireInMillis(expire, timeUnit, cache), TimeUnit.MILLISECONDS);
             } else {
-                long useExpireTime = Math.min(expire, cache.config().getExpireAfterWriteInMillis());
-                r = cache.PUT(key, value, useExpireTime, timeUnit);
+                r = cache.PUT(key, value, expire, timeUnit);
             }
             future = combine(future, r);
         }
         return new CacheResult(future);
+    }
+
+    private long limitedExpireInMillis(long expire, TimeUnit timeUnit, Cache cache) {
+        return Math.min(timeUnit.toMillis(expire), cache.config().getExpireAfterWriteInMillis());
     }
 
     private CompletableFuture<ResultData> combine(CompletableFuture<ResultData> future, CacheResult result) {

--- a/jetcache-core/src/main/java/com/alicp/jetcache/MultiLevelCache.java
+++ b/jetcache-core/src/main/java/com/alicp/jetcache/MultiLevelCache.java
@@ -61,12 +61,22 @@ public class MultiLevelCache<K, V> extends AbstractCache<K, V> {
 
     @Override
     public CacheResult PUT(K key, V value) {
-        return PUT(key, value, 0, null);
+        if (useExpireOfSubCacheForDefaultWrite()) {
+            return PUT(key, value, 0, null);
+        }
+        return PUT(key, value, config().getExpireAfterWriteInMillis(), TimeUnit.MILLISECONDS);
     }
 
     @Override
     public CacheResult PUT_ALL(Map<? extends K, ? extends V> map) {
-        return PUT_ALL(map, 0, null);
+        if (useExpireOfSubCacheForDefaultWrite()) {
+            return PUT_ALL(map, 0, null);
+        }
+        return PUT_ALL(map, config().getExpireAfterWriteInMillis(), TimeUnit.MILLISECONDS);
+    }
+
+    private boolean useExpireOfSubCacheForDefaultWrite() {
+        return !config().isUseExpireOfSubCacheConfigured() || config().isUseExpireOfSubCacheEnabled();
     }
 
     @Override

--- a/jetcache-core/src/main/java/com/alicp/jetcache/MultiLevelCacheBuilder.java
+++ b/jetcache-core/src/main/java/com/alicp/jetcache/MultiLevelCacheBuilder.java
@@ -40,6 +40,15 @@ public class MultiLevelCacheBuilder<T extends MultiLevelCacheBuilder<T>> extends
         getConfig().setCaches(caches);
     }
 
+    @Deprecated
+    public T useExpireOfSubCache(boolean useExpireOfSubCache) {
+        return self();
+    }
+
+    @Deprecated
+    public void setUseExpireOfSubCache(boolean useExpireOfSubCache) {
+    }
+
     @Override
     public T keyConvertor(Function<Object, Object> keyConvertor) {
         throw new UnsupportedOperationException("MultiLevelCache do not need a key convertor");

--- a/jetcache-core/src/main/java/com/alicp/jetcache/MultiLevelCacheBuilder.java
+++ b/jetcache-core/src/main/java/com/alicp/jetcache/MultiLevelCacheBuilder.java
@@ -42,11 +42,13 @@ public class MultiLevelCacheBuilder<T extends MultiLevelCacheBuilder<T>> extends
 
     @Deprecated
     public T useExpireOfSubCache(boolean useExpireOfSubCache) {
+        getConfig().setUseExpireOfSubCache(useExpireOfSubCache);
         return self();
     }
 
     @Deprecated
     public void setUseExpireOfSubCache(boolean useExpireOfSubCache) {
+        getConfig().setUseExpireOfSubCache(useExpireOfSubCache);
     }
 
     @Override

--- a/jetcache-core/src/main/java/com/alicp/jetcache/MultiLevelCacheBuilder.java
+++ b/jetcache-core/src/main/java/com/alicp/jetcache/MultiLevelCacheBuilder.java
@@ -40,15 +40,6 @@ public class MultiLevelCacheBuilder<T extends MultiLevelCacheBuilder<T>> extends
         getConfig().setCaches(caches);
     }
 
-    public T useExpireOfSubCache(boolean useExpireOfSubCache) {
-        getConfig().setUseExpireOfSubCache(useExpireOfSubCache);
-        return self();
-    }
-
-    public void setUseExpireOfSubCache(boolean useExpireOfSubCache) {
-        getConfig().setUseExpireOfSubCache(useExpireOfSubCache);
-    }
-
     @Override
     public T keyConvertor(Function<Object, Object> keyConvertor) {
         throw new UnsupportedOperationException("MultiLevelCache do not need a key convertor");

--- a/jetcache-core/src/main/java/com/alicp/jetcache/MultiLevelCacheConfig.java
+++ b/jetcache-core/src/main/java/com/alicp/jetcache/MultiLevelCacheConfig.java
@@ -10,7 +10,6 @@ import java.util.List;
  */
 public class MultiLevelCacheConfig<K, V> extends CacheConfig<K, V> {
     private List<Cache<K, V>> caches = new ArrayList<>();
-    private boolean useExpireOfSubCache;
 
     @Override
     public MultiLevelCacheConfig clone() {
@@ -27,13 +26,5 @@ public class MultiLevelCacheConfig<K, V> extends CacheConfig<K, V> {
 
     public void setCaches(List<Cache<K, V>> caches) {
         this.caches = caches;
-    }
-
-    public boolean isUseExpireOfSubCache() {
-        return useExpireOfSubCache;
-    }
-
-    public void setUseExpireOfSubCache(boolean useExpireOfSubCache) {
-        this.useExpireOfSubCache = useExpireOfSubCache;
     }
 }

--- a/jetcache-core/src/main/java/com/alicp/jetcache/MultiLevelCacheConfig.java
+++ b/jetcache-core/src/main/java/com/alicp/jetcache/MultiLevelCacheConfig.java
@@ -10,6 +10,7 @@ import java.util.List;
  */
 public class MultiLevelCacheConfig<K, V> extends CacheConfig<K, V> {
     private List<Cache<K, V>> caches = new ArrayList<>();
+    private boolean useExpireOfSubCache;
 
     @Override
     public MultiLevelCacheConfig clone() {
@@ -26,5 +27,15 @@ public class MultiLevelCacheConfig<K, V> extends CacheConfig<K, V> {
 
     public void setCaches(List<Cache<K, V>> caches) {
         this.caches = caches;
+    }
+
+    @Deprecated
+    public boolean isUseExpireOfSubCache() {
+        return useExpireOfSubCache;
+    }
+
+    @Deprecated
+    public void setUseExpireOfSubCache(boolean useExpireOfSubCache) {
+        this.useExpireOfSubCache = useExpireOfSubCache;
     }
 }

--- a/jetcache-core/src/main/java/com/alicp/jetcache/MultiLevelCacheConfig.java
+++ b/jetcache-core/src/main/java/com/alicp/jetcache/MultiLevelCacheConfig.java
@@ -10,7 +10,7 @@ import java.util.List;
  */
 public class MultiLevelCacheConfig<K, V> extends CacheConfig<K, V> {
     private List<Cache<K, V>> caches = new ArrayList<>();
-    private boolean useExpireOfSubCache;
+    private Boolean useExpireOfSubCache;
 
     @Override
     public MultiLevelCacheConfig clone() {
@@ -31,11 +31,19 @@ public class MultiLevelCacheConfig<K, V> extends CacheConfig<K, V> {
 
     @Deprecated
     public boolean isUseExpireOfSubCache() {
-        return useExpireOfSubCache;
+        return isUseExpireOfSubCacheEnabled();
     }
 
     @Deprecated
     public void setUseExpireOfSubCache(boolean useExpireOfSubCache) {
         this.useExpireOfSubCache = useExpireOfSubCache;
+    }
+
+    boolean isUseExpireOfSubCacheConfigured() {
+        return useExpireOfSubCache != null;
+    }
+
+    boolean isUseExpireOfSubCacheEnabled() {
+        return Boolean.TRUE.equals(useExpireOfSubCache);
     }
 }

--- a/jetcache-core/src/main/java/com/alicp/jetcache/SimpleCacheManager.java
+++ b/jetcache-core/src/main/java/com/alicp/jetcache/SimpleCacheManager.java
@@ -119,11 +119,9 @@ public class SimpleCacheManager implements CacheManager, AutoCloseable {
             Cache remote = buildRemote(config);
 
 
-            boolean useExpireOfSubCache = config.getLocalExpire() != null;
             cache = MultiLevelCacheBuilder.createMultiLevelCacheBuilder()
                     .expireAfterWrite(remote.config().getExpireAfterWriteInMillis(), TimeUnit.MILLISECONDS)
                     .addCache(local, remote)
-                    .useExpireOfSubCache(useExpireOfSubCache)
                     .cacheNullValue(config.getCacheNullValue() != null ?
                             config.getCacheNullValue() : DEFAULT_CACHE_NULL_VALUE)
                     .buildCache();

--- a/jetcache-test/pom.xml
+++ b/jetcache-test/pom.xml
@@ -124,6 +124,12 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
             <version>${jedis.version}</version>

--- a/jetcache-test/src/main/java/com/alicp/jetcache/test/beans/TestBean.java
+++ b/jetcache-test/src/main/java/com/alicp/jetcache/test/beans/TestBean.java
@@ -62,6 +62,11 @@ public class TestBean {
         return count++;
     }
 
+    @Cached(area = "LOCAL_EXPIRE", name = "cachedBothWithoutLocalExpire", cacheType = CacheType.BOTH, key = "#key")
+    public String cachedBothWithoutLocalExpire(String key) {
+        return "V_" + key + count++;
+    }
+
 
     @Cached(enabled = false)
     public int countWithDisabledCache(){

--- a/jetcache-test/src/test/java/com/alicp/jetcache/MultiLevelCacheTest.java
+++ b/jetcache-test/src/test/java/com/alicp/jetcache/MultiLevelCacheTest.java
@@ -169,7 +169,6 @@ public class MultiLevelCacheTest extends AbstractCacheTest {
 
     private void testUseExpireOfSubCache() throws Exception {
         long oldExpire = l1Cache.config().getExpireAfterWriteInMillis();
-        ((MultiLevelCacheConfig<Object, Object>)cache.config()).setUseExpireOfSubCache(true);
         l1Cache.config().setExpireAfterWriteInMillis(15);
 
         cache.put("useSubExpire_key", "V1");
@@ -194,7 +193,6 @@ public class MultiLevelCacheTest extends AbstractCacheTest {
         Assert.assertNull(l1Cache.get("useSubExpire_key"));
         cache.remove("useSubExpire_key");
 
-        ((MultiLevelCacheConfig<Object, Object>)cache.config()).setUseExpireOfSubCache(false);
         l1Cache.config().setExpireAfterAccessInMillis(oldExpire);
     }
 

--- a/jetcache-test/src/test/java/com/alicp/jetcache/MultiLevelCacheTest.java
+++ b/jetcache-test/src/test/java/com/alicp/jetcache/MultiLevelCacheTest.java
@@ -119,6 +119,46 @@ public class MultiLevelCacheTest extends AbstractCacheTest {
         });
     }
 
+    @Test
+    public void defaultPutAllShouldUseSubCacheExpire() {
+        initL1L2(200);
+        l1Cache.config().setExpireAfterWriteInMillis(50);
+        cache = MultiLevelCacheBuilder.createMultiLevelCacheBuilder()
+                .expireAfterWrite(200, TimeUnit.MILLISECONDS)
+                .addCache(l1Cache, l2Cache)
+                .buildCache();
+
+        long beforePut = System.currentTimeMillis();
+        cache.put("defaultPut_key", "V1");
+        assertHolderTtlLessThan("defaultPut_key", beforePut, 120);
+
+        Map map = new HashMap();
+        map.put("defaultPutAll_key", "V2");
+        long beforePutAll = System.currentTimeMillis();
+        cache.putAll(map);
+        assertHolderTtlLessThan("defaultPutAll_key", beforePutAll, 120);
+    }
+
+    @Test
+    public void explicitPutShouldNotBeCappedBySubCacheExpire() {
+        initL1L2(200);
+        l1Cache.config().setExpireAfterWriteInMillis(50);
+        cache = MultiLevelCacheBuilder.createMultiLevelCacheBuilder()
+                .expireAfterWrite(200, TimeUnit.MILLISECONDS)
+                .addCache(l1Cache, l2Cache)
+                .buildCache();
+
+        long beforePut = System.currentTimeMillis();
+        cache.put("explicitPut_key", "V1", 500, TimeUnit.MILLISECONDS);
+        assertHolderTtlGreaterThan("explicitPut_key", beforePut, 300);
+
+        Map map = new HashMap();
+        map.put("explicitPutAll_key", "V2");
+        long beforePutAll = System.currentTimeMillis();
+        cache.putAll(map, 500, TimeUnit.MILLISECONDS);
+        assertHolderTtlGreaterThan("explicitPutAll_key", beforePutAll, 300);
+    }
+
     private void doMonitoredTest(int expireMillis, boolean verboseLog, Runnable test) {
         initL1L2(expireMillis);
         DefaultCacheMonitor m1 = new DefaultCacheMonitor("l1");
@@ -201,5 +241,28 @@ public class MultiLevelCacheTest extends AbstractCacheTest {
             c = ((ProxyCache) c).getTargetCache();
         }
         return (AbstractCache) c;
+    }
+
+    private CacheValueHolder<Object> getL1Holder(Object key) {
+        AbstractCache c1 = getConcreteCache(l1Cache);
+        return (CacheValueHolder<Object>)
+                ((com.github.benmanes.caffeine.cache.Cache) c1.unwrap(com.github.benmanes.caffeine.cache.Cache.class))
+                        .getIfPresent(key);
+    }
+
+    private void assertHolderTtlLessThan(Object key, long startTime, long maxTtlMillis) {
+        CacheValueHolder<Object> holder = getL1Holder(key);
+        Assert.assertNotNull(holder);
+        long ttl = holder.getExpireTime() - startTime;
+        Assert.assertTrue("ttl should be less than " + maxTtlMillis + "ms but was " + ttl + "ms",
+                ttl < maxTtlMillis);
+    }
+
+    private void assertHolderTtlGreaterThan(Object key, long startTime, long minTtlMillis) {
+        CacheValueHolder<Object> holder = getL1Holder(key);
+        Assert.assertNotNull(holder);
+        long ttl = holder.getExpireTime() - startTime;
+        Assert.assertTrue("ttl should be greater than " + minTtlMillis + "ms but was " + ttl + "ms",
+                ttl > minTtlMillis);
     }
 }

--- a/jetcache-test/src/test/java/com/alicp/jetcache/MultiLevelCacheTest.java
+++ b/jetcache-test/src/test/java/com/alicp/jetcache/MultiLevelCacheTest.java
@@ -159,6 +159,28 @@ public class MultiLevelCacheTest extends AbstractCacheTest {
         assertHolderTtlGreaterThan("explicitPutAll_key", beforePutAll, 300);
     }
 
+    @SuppressWarnings("deprecation")
+    @Test
+    public void useExpireOfSubCacheFalseShouldKeepMultiLevelDefaultExpire() {
+        initL1L2(200);
+        l1Cache.config().setExpireAfterWriteInMillis(50);
+        cache = MultiLevelCacheBuilder.createMultiLevelCacheBuilder()
+                .expireAfterWrite(200, TimeUnit.MILLISECONDS)
+                .useExpireOfSubCache(false)
+                .addCache(l1Cache, l2Cache)
+                .buildCache();
+
+        long beforePut = System.currentTimeMillis();
+        cache.put("useMultiLevelExpire_key", "V1");
+        assertHolderTtlGreaterThan("useMultiLevelExpire_key", beforePut, 120);
+
+        Map map = new HashMap();
+        map.put("useMultiLevelExpireAll_key", "V2");
+        long beforePutAll = System.currentTimeMillis();
+        cache.putAll(map);
+        assertHolderTtlGreaterThan("useMultiLevelExpireAll_key", beforePutAll, 120);
+    }
+
     private void doMonitoredTest(int expireMillis, boolean verboseLog, Runnable test) {
         initL1L2(expireMillis);
         DefaultCacheMonitor m1 = new DefaultCacheMonitor("l1");

--- a/jetcache-test/src/test/java/com/alicp/jetcache/anno/filed/CreateCacheTest.java
+++ b/jetcache-test/src/test/java/com/alicp/jetcache/anno/filed/CreateCacheTest.java
@@ -189,13 +189,11 @@ public class CreateCacheTest extends SpringTest {
 
             private void testCacheWithLocalExpire() {
                 MultiLevelCacheConfig<?,?> config = (MultiLevelCacheConfig) cacheWithLocalExpire_1.config();
-                Assert.assertTrue(config.isUseExpireOfSubCache());
                 Assert.assertEquals(2000, config.getExpireAfterWriteInMillis());
                 Assert.assertEquals(1000, config.getCaches().get(0).config().getExpireAfterWriteInMillis());
                 Assert.assertEquals(2000, config.getCaches().get(1).config().getExpireAfterWriteInMillis());
 
                 config = (MultiLevelCacheConfig) cacheWithLocalExpire_2.config();
-                Assert.assertFalse(config.isUseExpireOfSubCache());
                 Assert.assertEquals(2000, config.getExpireAfterWriteInMillis());
                 Assert.assertEquals(2000, config.getCaches().get(0).config().getExpireAfterWriteInMillis());
                 Assert.assertEquals(2000, config.getCaches().get(1).config().getExpireAfterWriteInMillis());

--- a/jetcache-test/src/test/java/com/alicp/jetcache/anno/filed/CreateCacheTest.java
+++ b/jetcache-test/src/test/java/com/alicp/jetcache/anno/filed/CreateCacheTest.java
@@ -3,6 +3,7 @@ package com.alicp.jetcache.anno.filed;
 import com.alicp.jetcache.Cache;
 import com.alicp.jetcache.CacheManager;
 import com.alicp.jetcache.CacheResultCode;
+import com.alicp.jetcache.CacheValueHolder;
 import com.alicp.jetcache.LoadingCacheTest;
 import com.alicp.jetcache.MultiLevelCache;
 import com.alicp.jetcache.MultiLevelCacheConfig;
@@ -19,16 +20,21 @@ import com.alicp.jetcache.anno.config.EnableMethodCache;
 import com.alicp.jetcache.anno.support.ConfigProvider;
 import com.alicp.jetcache.anno.support.GlobalCacheConfig;
 import com.alicp.jetcache.anno.support.JetCacheBaseBeans;
+import com.alicp.jetcache.embedded.AbstractEmbeddedCache;
+import com.alicp.jetcache.embedded.EmbeddedCacheBuilder;
 import com.alicp.jetcache.embedded.EmbeddedCacheConfig;
 import com.alicp.jetcache.embedded.LinkedHashMapCache;
+import com.alicp.jetcache.embedded.LinkedHashMapCacheBuilder;
 import com.alicp.jetcache.external.ExternalCacheConfig;
 import com.alicp.jetcache.external.MockRemoteCache;
+import com.alicp.jetcache.external.MockRemoteCacheBuilder;
 import com.alicp.jetcache.support.Fastjson2KeyConvertor;
 import com.alicp.jetcache.support.JavaValueDecoder;
 import com.alicp.jetcache.support.JavaValueEncoder;
 import com.alicp.jetcache.test.AbstractCacheTest;
 import com.alicp.jetcache.test.anno.TestUtil;
 import com.alicp.jetcache.test.beans.MyFactoryBean;
+import com.alicp.jetcache.test.beans.TestBean;
 import com.alicp.jetcache.test.spring.SpringTest;
 import com.alicp.jetcache.test.support.DynamicQuery;
 import com.alicp.jetcache.test.support.DynamicQueryWithEquals;
@@ -44,6 +50,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import javax.annotation.PostConstruct;
+import java.util.LinkedHashMap;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -54,6 +61,10 @@ import java.util.concurrent.TimeUnit;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = CreateCacheTest.A.class)
 public class CreateCacheTest extends SpringTest {
+
+    private static final String LOCAL_EXPIRE_AREA = "LOCAL_EXPIRE";
+    private static final long LOCAL_EXPIRE_MILLIS = 1000;
+    private static final long REMOTE_EXPIRE_MILLIS = 10000;
 
     @Test
     public void test() throws Exception {
@@ -70,6 +81,17 @@ public class CreateCacheTest extends SpringTest {
         @Bean
         public GlobalCacheConfig config() {
             GlobalCacheConfig pc = TestUtil.createGloableConfig();
+            EmbeddedCacheBuilder localBuilder = LinkedHashMapCacheBuilder.createLinkedHashMapCacheBuilder()
+                    .keyConvertor(Fastjson2KeyConvertor.INSTANCE)
+                    .expireAfterWrite(LOCAL_EXPIRE_MILLIS, TimeUnit.MILLISECONDS);
+            pc.getLocalCacheBuilders().put(LOCAL_EXPIRE_AREA, localBuilder);
+
+            MockRemoteCacheBuilder remoteBuilder = MockRemoteCacheBuilder.createMockRemoteCacheBuilder();
+            remoteBuilder.setKeyConvertor(Fastjson2KeyConvertor.INSTANCE);
+            remoteBuilder.setValueEncoder(JavaValueEncoder.INSTANCE);
+            remoteBuilder.setValueDecoder(JavaValueDecoder.INSTANCE);
+            remoteBuilder.setExpireAfterWriteInMillis(REMOTE_EXPIRE_MILLIS);
+            pc.getRemoteCacheBuilders().put(LOCAL_EXPIRE_AREA, remoteBuilder);
             return pc;
         }
 
@@ -90,6 +112,9 @@ public class CreateCacheTest extends SpringTest {
 
             @Autowired
             private CacheManager cacheManager;
+
+            @Autowired
+            private TestBean testBean;
 
             @CreateCache
             private Cache cache1;
@@ -135,6 +160,9 @@ public class CreateCacheTest extends SpringTest {
             @CreateCache(expire = 2, localExpire = 1, cacheType = CacheType.LOCAL)
             private Cache cacheWithLocalExpire_3;
 
+            @CreateCache(area = LOCAL_EXPIRE_AREA, cacheType = CacheType.BOTH)
+            private Cache createCacheBothWithoutLocalExpire;
+
 
             private Cache getTarget(Cache cache) {
                 while(cache instanceof ProxyCache){
@@ -150,6 +178,7 @@ public class CreateCacheTest extends SpringTest {
                 cacheWithoutConvertorTest();
                 AbstractCacheTest.penetrationProtectTest(cacheWithProtect);
                 testCacheWithLocalExpire();
+                testAnnotationBothCacheUsesLocalBuilderExpire();
 
                 cache1.put("KK1", "V1");
                 Assert.assertNull(cache_A1.get("KK1"));
@@ -199,6 +228,37 @@ public class CreateCacheTest extends SpringTest {
                 Assert.assertEquals(2000, config.getCaches().get(1).config().getExpireAfterWriteInMillis());
 
                 Assert.assertEquals(2000, cacheWithLocalExpire_3.config().getExpireAfterWriteInMillis());
+            }
+
+            private void testAnnotationBothCacheUsesLocalBuilderExpire() {
+                String createCacheKey = "createCacheBothWithoutLocalExpire_key";
+                long beforeCreateCachePut = System.currentTimeMillis();
+                createCacheBothWithoutLocalExpire.put(createCacheKey, "V1");
+                assertLocalHolderUsesLocalBuilderExpire(createCacheBothWithoutLocalExpire, createCacheKey,
+                        beforeCreateCachePut);
+
+                String cachedKey = "cachedBothWithoutLocalExpire_key";
+                long beforeCachedInvoke = System.currentTimeMillis();
+                testBean.cachedBothWithoutLocalExpire(cachedKey);
+                Cache cached = cacheManager.getCache(LOCAL_EXPIRE_AREA, "cachedBothWithoutLocalExpire");
+                assertLocalHolderUsesLocalBuilderExpire(cached, cachedKey, beforeCachedInvoke);
+            }
+
+            private void assertLocalHolderUsesLocalBuilderExpire(Cache cache, Object key, long startTime) {
+                MultiLevelCache multiLevelCache = (MultiLevelCache) getTarget(cache);
+                Cache localCache = getTarget(multiLevelCache.caches()[0]);
+                Cache remoteCache = getTarget(multiLevelCache.caches()[1]);
+                Assert.assertEquals(REMOTE_EXPIRE_MILLIS, multiLevelCache.config().getExpireAfterWriteInMillis());
+                Assert.assertEquals(LOCAL_EXPIRE_MILLIS, localCache.config().getExpireAfterWriteInMillis());
+                Assert.assertEquals(REMOTE_EXPIRE_MILLIS, remoteCache.config().getExpireAfterWriteInMillis());
+
+                Object builtKey = ((AbstractEmbeddedCache) localCache).buildKey(key);
+                LinkedHashMap localMap = (LinkedHashMap) localCache.unwrap(LinkedHashMap.class);
+                CacheValueHolder holder = (CacheValueHolder) localMap.get(builtKey);
+                Assert.assertNotNull(holder);
+                long localTtl = holder.getExpireTime() - startTime;
+                Assert.assertTrue("local ttl should use local builder expire but was " + localTtl + "ms",
+                        localTtl > 0 && localTtl < REMOTE_EXPIRE_MILLIS / 2);
             }
 
             private void runGeneralTest() throws Exception {


### PR DESCRIPTION
Resolves #915

TODO:

- [x] verify annotation can be overridden by environment variable
- [x] verify local expiration time wasn't greater than remote when `@Cache(type=BOTH)` and not setting localExpire